### PR TITLE
Ivgonchar/fix pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,7 @@
     <version>1.1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <properties>
-        <java.version>11</java.version>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.release>11</maven.compiler.release>
         <lombok.version>1.18.12</lombok.version>
         <mysql.driver.version>8.0.16</mysql.driver.version>
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
@@ -33,11 +31,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>${maven.compiler.plugin.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -240,6 +233,11 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <version>${spring.boot.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!--Data Mapping-->

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <version>1.1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
         <lombok.version>1.18.12</lombok.version>
         <mysql.driver.version>8.0.16</mysql.driver.version>
@@ -80,7 +81,7 @@
             <version>${hibernate.entitymanager.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate.validator.version}</version>
         </dependency>
@@ -242,6 +243,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
                 <configuration>
                     <mainClass>com.notspend.Application</mainClass>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,13 @@
                 <configuration>
                     <mainClass>com.notspend.Application</mainClass>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -253,22 +260,6 @@
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <mainClass>com.notspend.Application</mainClass>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
I suggest following fix:
* Fix java version settings in pom.xml

java.version maven property is useless here. It is a property defined in spring-boot-starter-parent pom.
It is defined in following way there:
```
    <java.version>1.8</java.version>
    <maven.compiler.source>${java.version}</maven.compiler.source>
    <maven.compiler.target>${java.version}</maven.compiler.target>
```
So, when you set value for this property it sets 2 properties: maven.compiler.source and maven.compiler.target.
But when you don't use spring-boot-starter-parent this property is useless
Also latest versions of maven compiler plugin defines a property which works similar way.
This property is `maven.compiler.release`

Some more information may be found here:
https://www.baeldung.com/maven-java-version
https://stackoverflow.com/questions/38882080/specifying-java-version-in-maven-differences-between-properties-and-compiler-p
https://stackoverflow.com/questions/54467287/how-to-specify-java-11-version-in-spring-spring-boot-pom-xml

Your project doesn't depend on maven-compiler-plugin (generally projects should not depend on maven plugins. Maven plugins are used only during the build).
If you need to upgrade maven plugin version you should specify it in `<build>` section.
It is often required to upgrade standard maven plugin versions, because default versions are outdated.

* Set correct scope for Spring Boot Devtools

Despite even if with compile scope it will work, but it is more correct to set runtime scope for this dependency. This dependency is not required for compilation, thus it shouldn't be in compile scope

* Merge spring boot maven plugin declarations

trivial issues fixed

* Fix warnings during maven build

trivial issues fixed
hibernate-validator groupid was changed. It is better to use new groupId - org.hibernate.validator (seems, future versions will be available only with this groupId)